### PR TITLE
Clean up action/tooltip deactivation

### DIFF
--- a/qiceradar_selection_widget.py
+++ b/qiceradar_selection_widget.py
@@ -51,11 +51,18 @@ class QIceRadarSelectionTool(QgsMapTool):
 
     def __init__(self, canvas: QgsMapCanvas) -> None:
         super(QIceRadarSelectionTool, self).__init__(canvas)
+        self.canvas = canvas
 
     def canvasReleaseEvent(self, event: QgsMapMouseEvent) -> None:
         pt = event.mapPoint()
         self.selected_point.emit(pt)
-        self.deactivate()
+        # According to the docs, I thought that deactivate() was supposed to
+        # call unsetMapTool(), but the selection tooltip is still active
+        # afterwards. So, go ahead and call it explicitly since we only expect
+        # the user to select one thing in a row.
+        # (unsetMapTool does cause the deactivate signal to be emitted)
+        # self.deactivate()
+        self.canvas.unsetMapTool(self)
 
 
 class QIceRadarSelectionWidget(QtWidgets.QDialog):


### PR DESCRIPTION
* Get rid of caching previous MapTool, since it may not stay valid
* Use unsetMapTool to deactivate the QIceRadar tooltip without explicitly setting a new active MapTool